### PR TITLE
add library debuging method

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,5 +31,33 @@
 			"externalConsole": true,
 			"preLaunchTask": "minishell-make",
 		},
+		{
+			"name": "libft-linux",
+			"type": "cppdbg",
+			"request": "launch",
+			"program": "${workspaceFolder}/tmp/dev/libft/libft_debug.out",
+			"args": [
+				// if you want to pass arguments to your program
+			],
+			"stopAtEntry": false,
+			"cwd": "${fileDirname}",
+			"environment": [],
+			"MIMode": "gdb",
+			"preLaunchTask": "libft-make",
+		},
+		{
+			"name": "libft-mac",
+			"type": "cppdbg",
+			"request": "launch",
+			"program": "${workspaceFolder}/tmp/dev/libft/libft_debug.out",
+			"args": [
+				// if you want to pass arguments to your program
+			],
+			"stopAtEntry": false,
+			"cwd": "${fileDirname}",
+			"environment": [],
+			"MIMode": "lldb",
+			"preLaunchTask": "libft-make",
+		},
 	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+	"files.associations": {
+		"libft.h": "c"
+	}
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,6 +16,22 @@
             ],
 			"group": "build",
 		},
+		{
+			"type": "cppbuild",
+			"label": "libft-make",
+			"command": "make",
+			"args": [
+				"test", "DEBUG_MODE=1",
+				"-C", "${workspaceFolder}/test/libft"
+			],
+			"options": {
+				"cwd": "${fileDirname}"
+			},
+            "problemMatcher": [
+                "$gcc"
+            ],
+			"group": "build",
+		},
     ],
     "version": "2.0.0"
 }

--- a/test/libft/Makefile
+++ b/test/libft/Makefile
@@ -1,0 +1,39 @@
+# Library TEST Makefile
+
+# Hyper Parameter
+MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+BASE_DIRNAME := $(shell basename ${MAKEFILE_DIR})
+REPOSITORY_ROOT := $(abspath $(MAKEFILE_DIR)/../../)
+
+include $(REPOSITORY_ROOT)/src/$(BASE_DIRNAME)/Makefile
+
+# Parameters
+NAME := libft.out
+DNAME := $(NAME:.out=_debug.out)
+
+NAME := $(addprefix $(OBJ_DIR),$(NAME))
+DNAME := $(addprefix $(DOBJ_DIR),$(DNAME))
+
+TEST_SRC_DIR := $(addprefix $(REPOSITORY_ROOT),/test/$(BASE_DIRNAME)/)
+TEST_SRCS := main.c
+
+TEST_SRCS := $(addprefix $(TEST_SRC_DIR),$(TEST_SRCS)) 
+
+TEST_OBJS := $(patsubst $(TEST_SRC_DIR)%.c,$(OBJ_DIR)%.o,$(TEST_SRCS))
+TEST_DOBJS := $(patsubst $(TEST_SRC_DIR)%.c,$(DOBJ_DIR)%.o,$(TEST_SRCS))
+
+# Rules
+ifdef DEBUG_MODE
+TEST_OBJS := $(TEST_DOBJS)
+NAME := $(DNAME)
+endif
+
+# Rules
+.PHONY: test
+test: $(OBJ_DIR) $(NAME)
+
+$(NAME): $(OBJS) $(TEST_OBJS)
+	$(CC) $(CFLAGS) $(OBJS) $(TEST_OBJS) $(LFLAGS) -o $(NAME)
+
+$(OBJ_DIR)%.o: $(TEST_SRC_DIR)%.c $(HEADERS)
+	$(CC) $(CFLAGS) $(IFLAGS) $(LFLAGS) -c $< -o $@

--- a/test/libft/main.c
+++ b/test/libft/main.c
@@ -1,0 +1,43 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   main.c                                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: saraki <saraki@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/03/01 14:42:06 by saraki            #+#    #+#             */
+/*   Updated: 2024/03/01 15:01:39 by saraki           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+
+#include <stdio.h>
+
+int	main()
+{
+	char	*result = ft_itoa(2147483647);
+	printf("%s\n", result);
+	free(result);
+	result = NULL;
+
+	result = ft_itoa(-2147483648);
+	printf("%s\n", result);
+	free(result);
+	result = NULL;
+
+	result = ft_itoa(100);
+	printf("%s\n", result);
+	free(result);
+	result = NULL;
+
+	result = ft_itoa(0);
+	printf("%s\n", result);
+	free(result);
+	result = NULL;
+
+	result = ft_itoa(-100);
+	printf("%s\n", result);
+	free(result);
+	result = NULL;
+}


### PR DESCRIPTION
ご想像の通り、アーカイブファイル(*.a)にしてしまったらまともなデバッグが行いにくい。
そのため、testディレクトリ内に同名ライブラリ名と、内部にmain.cとMakefileを配置することにより、ステップイン、ステップアウトを行えるようにした。

```sh
$ tree test
test
└── libft
    ├── main.c
    └── Makefile

1 directory, 2 files

$ make test -C test/libft
make: Entering directory '/workspace/repo/minishell/test/libft'
mkdir -p /workspace/repo/minishell/tmp/prod/libft/./
mkdir -p /workspace/repo/minishell/lib/
cc -Wall -Wextra -Werror -I/workspace/repo/minishell/include/  -c /workspace/repo/minishell/src/libft/ft_atoi.c -o /workspace/repo/minishell/tmp/prod/libft/ft_atoi.o
# ...
make: Leaving directory '/workspace/repo/minishell/test/libft'

$ ./tmp/dev/libft/libft_debug.out
2147483647
-2147483648
100
0
-100
```