### PR TITLE
fix: リダイレクトが左端にある場合のバグの修正

### DIFF
--- a/src/exec/Makefile
+++ b/src/exec/Makefile
@@ -17,6 +17,7 @@ SRCS += make_processes_util.c
 SRCS += process_callback.c
 SRCS += parse_cmd.c
 SRCS += parse_redirects.c
+SRCS += parse_redirects_util.c
 SRCS += exec_bridge.c
 
 LIB_EXPORT_DIR := $(addprefix $(REPOSITORY_ROOT),/lib/)

--- a/src/exec/exec_int.h
+++ b/src/exec/exec_int.h
@@ -53,6 +53,8 @@ int				make_process(t_exec_parametors *param, t_callback callback);
 char			**parse_cmd(t_tokenlst *head_node, t_pipex *pipe);
 char			*find_cmd(char *path, char **env, int *status);
 void			parse_redirects(t_tokenlst **now_node, t_pipex *pipe);
+int				open_in_files(char *dist, t_pipex *pipex, int heredocflag);
+int				open_out_files(char *dist, t_pipex *pipex, int appendflag);
 void			do_first_process(t_callback_parametors *params);
 void			do_middle_process(t_callback_parametors *params);
 void			do_last_process(t_callback_parametors *params);

--- a/src/exec/parse_redirects.c
+++ b/src/exec/parse_redirects.c
@@ -13,11 +13,8 @@
 #include "exec_int.h"
 
 static int	redirection(t_tokenlst **now_node, t_pipex *pipe);
-static int	open_in_files(char *dist, t_pipex *pipex, int heredocflag);
-static int	open_out_files(char *dist, t_pipex *pipex, int appendflag);
-static int	open_and_send_string_to_fd(char *str);
-
 static int	redirection_for_leftend(t_tokenlst **now_node, t_pipex *pipe);
+static void	open_io_files(char *symbol, char *dist, t_pipex *pipe);
 
 // # Description
 // This function merges the redirection tokens into one token.
@@ -58,14 +55,7 @@ static int	redirection(t_tokenlst **now_node, t_pipex *pipe)
 
 	symbol = (t_tokenlst *)doub_lstpurge((void **)now_node);
 	dist = (t_tokenlst *)doub_lstpurge((void **)now_node);
-	if (ft_strcmp(symbol->u_data.str, ">") == 0)
-		open_out_files(dist->u_data.str, pipe, 0);
-	else if (ft_strcmp(symbol->u_data.str, ">>") == 0)
-		open_out_files(dist->u_data.str, pipe, 1);
-	else if (ft_strcmp(symbol->u_data.str, "<") == 0)
-		open_in_files(dist->u_data.str, pipe, 0);
-	else if (ft_strcmp(symbol->u_data.str, "<<") == 0)
-		open_in_files(dist->u_data.str, pipe, 1);
+	open_io_files(symbol->u_data.str, dist->u_data.str, pipe);
 	doub_lstdelone((void *)symbol, NULL);
 	doub_lstdelone((void *)dist, NULL);
 	return (OK);
@@ -86,14 +76,7 @@ static int	redirection_for_leftend(t_tokenlst **now_node, t_pipex *pipe)
 	(*now_node) = (*now_node)->next;
 	dist = (t_tokenlst *)doub_lstpurge((void **)now_node);
 	(*now_node) = (*now_node)->prev;
-	if (ft_strcmp(symbol, ">") == 0)
-		open_out_files(dist->u_data.str, pipe, 0);
-	else if (ft_strcmp(symbol, ">>") == 0)
-		open_out_files(dist->u_data.str, pipe, 1);
-	else if (ft_strcmp(symbol, "<") == 0)
-		open_in_files(dist->u_data.str, pipe, 0);
-	else if (ft_strcmp(symbol, "<<") == 0)
-		open_in_files(dist->u_data.str, pipe, 1);
+	open_io_files(symbol, dist->u_data.str, pipe);
 	doub_lstdelone((void *)dist, NULL);
 	if ((*now_node)->next != NULL)
 	{
@@ -109,59 +92,14 @@ static int	redirection_for_leftend(t_tokenlst **now_node, t_pipex *pipe)
 	return (OK);
 }
 
-static int	open_in_files(char *dist, t_pipex *pipex, int heredocflag)
+static void	open_io_files(char *symbol, char *dist, t_pipex *pipe)
 {
-	int	fd;
-
-	if (dist && access(dist, R_OK) == 0 && heredocflag == 0)
-		pipex->file_in_fd = open(dist, O_RDONLY);
-	else if (dist && heredocflag)
-	{
-		fd = open_and_send_string_to_fd(dist);
-		pipex->file_in_fd = fd;
-	}
-	if (pipex->file_in_fd == -1)
-	{
-		close(pipex->file_in_fd);
-		close(pipex->file_out_fd);
-		return (ERR);
-	}
-	return (OK);
-}
-
-static int	open_out_files(char *dist, t_pipex *pipex, int appendflag)
-{
-	if (dist && access(dist, F_OK) == -1 && appendflag == 0)
-		pipex->file_out_fd = open(
-				dist, O_CREAT | O_WRONLY, S_IREAD | S_IWRITE);
-	else if (dist && access(dist, F_OK) == 0 && appendflag == 0)
-		pipex->file_out_fd = open(dist, O_WRONLY);
-	else if (dist && access(dist, F_OK) == -1 && appendflag)
-		pipex->file_out_fd = open(
-				dist, O_CREAT | O_WRONLY | O_APPEND, S_IREAD | S_IWRITE);
-	else if (dist && access(dist, F_OK) == 0 && appendflag)
-		pipex->file_out_fd = open(dist, O_WRONLY | O_APPEND);
-	if (pipex->file_out_fd == -1)
-	{
-		close(pipex->file_in_fd);
-		close(pipex->file_out_fd);
-		return (ERR);
-	}
-	return (OK);
-}
-
-static int	open_and_send_string_to_fd(char *str)
-{
-	int	fd[2];
-
-	if (pipe(fd) == -1)
-		return (ERR);
-	if (write(fd[1], str, ft_strlen(str)) == -1)
-	{
-		close(fd[0]);
-		close(fd[1]);
-		return (ERR);
-	}
-	close(fd[1]);
-	return (fd[0]);
+	if (ft_strcmp(symbol, ">") == 0)
+		open_out_files(dist, pipe, 0);
+	else if (ft_strcmp(symbol, ">>") == 0)
+		open_out_files(dist, pipe, 1);
+	else if (ft_strcmp(symbol, "<") == 0)
+		open_in_files(dist, pipe, 0);
+	else if (ft_strcmp(symbol, "<<") == 0)
+		open_in_files(dist, pipe, 1);
 }

--- a/src/exec/parse_redirects_util.c
+++ b/src/exec/parse_redirects_util.c
@@ -1,0 +1,72 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parse_redirects_util.c                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: syamasaw <syamasaw@student.42.fr>          #+#  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024-07-18 03:49:14 by syamasaw          #+#    #+#             */
+/*   Updated: 2024-07-18 03:49:14 by syamasaw         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "exec_int.h"
+
+static int	open_and_send_string_to_fd(char *str);
+
+int	open_in_files(char *dist, t_pipex *pipex, int heredocflag)
+{
+	int	fd;
+
+	if (dist && access(dist, R_OK) == 0 && heredocflag == 0)
+		pipex->file_in_fd = open(dist, O_RDONLY);
+	else if (dist && heredocflag)
+	{
+		fd = open_and_send_string_to_fd(dist);
+		pipex->file_in_fd = fd;
+	}
+	if (pipex->file_in_fd == -1)
+	{
+		close(pipex->file_in_fd);
+		close(pipex->file_out_fd);
+		return (ERR);
+	}
+	return (OK);
+}
+
+int	open_out_files(char *dist, t_pipex *pipex, int appendflag)
+{
+	if (dist && access(dist, F_OK) == -1 && appendflag == 0)
+		pipex->file_out_fd = open(
+				dist, O_CREAT | O_WRONLY, S_IREAD | S_IWRITE);
+	else if (dist && access(dist, F_OK) == 0 && appendflag == 0)
+		pipex->file_out_fd = open(dist, O_WRONLY);
+	else if (dist && access(dist, F_OK) == -1 && appendflag)
+		pipex->file_out_fd = open(
+				dist, O_CREAT | O_WRONLY | O_APPEND, S_IREAD | S_IWRITE);
+	else if (dist && access(dist, F_OK) == 0 && appendflag)
+		pipex->file_out_fd = open(dist, O_WRONLY | O_APPEND);
+	if (pipex->file_out_fd == -1)
+	{
+		close(pipex->file_in_fd);
+		close(pipex->file_out_fd);
+		return (ERR);
+	}
+	return (OK);
+}
+
+static int	open_and_send_string_to_fd(char *str)
+{
+	int	fd[2];
+
+	if (pipe(fd) == -1)
+		return (ERR);
+	if (write(fd[1], str, ft_strlen(str)) == -1)
+	{
+		close(fd[0]);
+		close(fd[1]);
+		return (ERR);
+	}
+	close(fd[1]);
+	return (fd[0]);
+}


### PR DESCRIPTION
Fix #97

## バグの原因
parse_redirects()はリダイレクト記号とリダイレクト先のファイルを示すnodeを削除するredirection()を呼び出している。
リダイレクト記号が左端にあった場合、これらを削除すると、リストの先頭ポインタがinit_nodeに保存した先頭ポインタと異なるものになっていた。その後、init_nodeをnow_nodeに戻したためにセグフォが起こっていた。

## 解決策
`< infile echo a`のようなコマンドの場合、<のnodeに対してechoの情報(u_data)をコピーし、infileとechoをパージして削除するように変更した。
また、`< infile`のようなリダイレクトのみのコマンドの場合は、<にNULLをコピーするようにした。
