### PR TITLE
fix: リダイレクションに関してのセグフォを修正

### DIFF
--- a/src/builtin/core.c
+++ b/src/builtin/core.c
@@ -6,7 +6,7 @@
 /*   By: saraki <saraki@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/16 03:56:27 by syamasaw          #+#    #+#             */
-/*   Updated: 2024/08/03 09:13:10 by saraki           ###   ########.fr       */
+/*   Updated: 2024/08/13 11:31:06 by saraki           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,6 +20,8 @@
  */
 int	is_builtin(char *cmd)
 {
+	if (cmd == NULL)
+		return (0);
 	if (ft_strcmp(cmd, "echo") == 0)
 		return (1);
 	if (ft_strcmp(cmd, "cd") == 0)

--- a/src/exec/make_processes_util.c
+++ b/src/exec/make_processes_util.c
@@ -6,7 +6,7 @@
 /*   By: saraki <saraki@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/04 15:25:30 by saraki            #+#    #+#             */
-/*   Updated: 2024/08/10 10:37:29 by saraki           ###   ########.fr       */
+/*   Updated: 2024/08/13 11:36:42 by saraki           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,7 +74,7 @@ static int	run_command(t_callback_parametors *callback_args,
 	callback_args->pipe->pids = fork();
 	if (callback_args->pipe->pids == 0)
 		callback(callback_args);
-	if (ft_strcmp(cmd[0], "exit") == 0
+	if (cmd[0] != NULL && ft_strcmp(cmd[0], "exit") == 0
 		&& pipe_cnt - 1 == (size_t) param->pipe_list->u_data.pipe_data->index)
 		param->is_exit_called = 1;
 	if (callback_args->path != NULL)


### PR DESCRIPTION
`< test | echo a`のように1ノードにリダイレクションがあり、パイプ内部が空になる場合にセグフォが発生していた。