### PR TITLE
shlvlの実装

### DIFF
--- a/cmd/minishell/minishell.c
+++ b/cmd/minishell/minishell.c
@@ -25,6 +25,7 @@
 
 volatile sig_atomic_t	g_signal = 0;
 
+static void	*init_envlst(char **envp);
 static int	main_loop(void *env_lst);
 static int	execute(char *line, void *env_lst, void *tokens_lst);
 static int	is_blank_str(char *str);
@@ -36,7 +37,7 @@ int	main(int argc, char **argv, char **envp)
 
 	(void)argc;
 	(void)argv;
-	env_lst = create_envlist(envp);
+	env_lst = init_envlst(envp);
 	if (env_lst == NULL)
 		return (1);
 	while (CONTINUE)
@@ -53,6 +54,21 @@ int	main(int argc, char **argv, char **envp)
 	}
 	doub_lstdelall(&env_lst, free_env_data);
 	return (OK);
+}
+
+static void	*init_envlst(char **envp)
+{
+	void	*env_lst;
+
+	env_lst = create_envlist(envp);
+	if (env_lst == NULL)
+		return (NULL);
+	if (update_shlvl(&env_lst))
+	{
+		doub_lstdelall(&env_lst, free_env_data);
+		return (NULL);
+	}
+	return (env_lst);
 }
 
 static int	main_loop(void *env_lst)

--- a/include/env.h
+++ b/include/env.h
@@ -32,4 +32,7 @@ void	print_env(void *env_lst);
 // sort_env.c
 void	qsort_env(char **env, int low, int high);
 
+// update_shlvl.c
+int		update_shlvl(void **envlst);
+
 #endif

--- a/src/env/Makefile
+++ b/src/env/Makefile
@@ -15,6 +15,7 @@ SRCS += convert_envlst.c
 SRCS += add_shell_env.c
 SRCS += print_env.c
 SRCS += sort_env.c
+SRCS += update_shlvl.c
 
 LIB_EXPORT_DIR := $(addprefix $(REPOSITORY_ROOT),/lib/)
 HEADER_DIR := $(addprefix $(REPOSITORY_ROOT),/include/)

--- a/src/env/env_int.h
+++ b/src/env/env_int.h
@@ -16,6 +16,9 @@
 # define IS_EXPORTED 1
 # define NOT_EXPORTED 0
 
+# define SHLVL_MAX 1000
+# define SHLVL_MIN 0
+
 # include "common.h"
 # include "libft.h"
 
@@ -32,5 +35,8 @@ int			cmp_key(void *data, void *query_pt);
 // convert_envlst.c
 char		**convert_envlst_to_arr(t_blst *env_lst);
 void		free_environment_array(char **env);
+
+// update_shlvl.c
+int			update_shlvl(void **envlst);
 
 #endif

--- a/src/env/update_shlvl.c
+++ b/src/env/update_shlvl.c
@@ -1,0 +1,75 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   update_shlvl.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: syamasaw <syamasaw@student.42.fr>          #+#  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024-08-16 09:50:51 by syamasaw          #+#    #+#             */
+/*   Updated: 2024-08-16 09:50:51 by syamasaw         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "env_int.h"
+#include "dbllst.h"
+
+static int	analyze_current_shlvl(char *shlvl_val);
+static int	set_shlvl(int shlvl);
+
+int	update_shlvl(void **envlst)
+{
+	t_blst	*shlvl_node;
+	int		shlvl;
+	char	*new;
+
+	shlvl_node = (t_blst *)doub_lstsearch(*envlst, "SHLVL", cmp_key);
+	if (shlvl_node->u_data.env_data != NULL)
+	{
+		shlvl = analyze_current_shlvl(shlvl_node->u_data.env_data->val);
+		shlvl = set_shlvl(shlvl);
+		free(shlvl_node->u_data.env_data->val);
+		new = ft_itoa(shlvl + 1);
+		if (new == NULL)
+			return (ERR);
+		shlvl_node->u_data.env_data->val = ft_strdup(new);
+		free(new);
+		return (OK);
+	}
+	return (add_shell_env("SHLVL", "1", envlst));
+}
+
+static int	analyze_current_shlvl(char *shlvl_val)
+{
+	int		i;
+	int		shlvl;
+
+	if (shlvl_val == NULL || shlvl_val[0] == '\0')
+		return (0);
+	i = -1;
+	while (shlvl_val[++i] != '\0')
+	{
+		if (!ft_isdigit(shlvl_val[i]))
+		{
+			if (i == 0 && (shlvl_val[i] == '-' || shlvl_val[i] == '+'))
+				continue ;
+			return (0);
+		}
+	}
+	shlvl = ft_atoi(shlvl_val);
+	return (shlvl);
+}
+
+static int	set_shlvl(int shlvl)
+{
+	if (shlvl < 0)
+		return (-1);
+	else if (shlvl + 1 >= SHLVL_MAX)
+	{
+		ft_putstr_fd(MSG_PREFIX, 2);
+		ft_putstr_fd("warning: shell level (", 2);
+		ft_putnbr_fd(shlvl + 1, 2);
+		ft_putstr_fd(") too high, resetting to 1\n", 2);
+		return (SHLVL_MIN);
+	}
+	return (shlvl);
+}


### PR DESCRIPTION
fix #139 

以下の条件に従い、SHLVLを実装した。
- SHLVL >= 0のときshellを呼ぶと、SHLVL=SHLVL+1
- SHLVL=999のときshellを呼ぶと、エラーを表示しSHLVL=1にリセット(`minishell: warning: shell level (1000) too high, resetting to 1`)
- SHLVL < 0のときshellを呼ぶと、SHLVL=0
- SHLVL先頭の符号を除き、SHLVLに数字以外が含まれる場合にshellを呼ぶと、SHLVL=1
- SHLVLがunsetされているか、valが設定されていない場合にshellを呼ぶと、SHLVL=1