### PR TITLE
envを修正

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -124,7 +124,7 @@ int		cd_move_err(char *path);
 int		export_option_err(char flag_char);
 int		export_identifier_err(char *str);
 
-int		env_err(void);
+int		env_err(char *cmd);
 
 int		pwd_err(char *str);
 

--- a/src/builtin/builtin_env.c
+++ b/src/builtin/builtin_env.c
@@ -45,8 +45,9 @@ static int	valid_option(char **cmd)
 {
 	if (cmd[1] != NULL)
 	{
-		env_err();
-		return (MISUSE_OF_SHELL_BUILTINS);
+		if (ft_strcmp(cmd[1], "--") == 0)
+			return (OK);
+		return (env_err(cmd[1]));
 	}
 	return (OK);
 }

--- a/src/common/bin_err_env.c
+++ b/src/common/bin_err_env.c
@@ -12,10 +12,11 @@
 
 #include "common.h"
 
-int	env_err(void)
+int	env_err(char *cmd)
 {
 	ft_putstr_fd(MSG_PREFIX, 2);
 	ft_putstr_fd("env: ", 2);
-	ft_putstr_fd("option is undefined\n", 2);
-	return (GENERAL_ERR);
+	ft_putstr_fd(cmd, 2);
+	ft_putstr_fd(": options and arguments are not allowed\n", 2);
+	return (MISUSE_OF_SHELL_BUILTINS);
 }


### PR DESCRIPTION
fix #145

- `env` / `env --`
実行され、exit 0
- `env -` / `env --hoge` / `env -hoge` / `env hoge`
エラー`minishell: env: -hoge: options and arguments are not allowed`を表示し、exit 2

