### PR TITLE
cat << EOF時にCtrl+Dしたときの挙動

### DIFF
--- a/src/tokens/heredoc.c
+++ b/src/tokens/heredoc.c
@@ -12,9 +12,9 @@
 
 #include "tokens_int.h"
 
-static char	*get_delimiter(char *delimiter_str);
-static int	replace_delimiter_as_token(
-				char *delimiter_str, t_blst **delimiter_node);
+static int	get_and_replace_delim(t_blst *now_node);
+static char	*get_delimiter(t_blst *now_node);
+static int	replace_delim_as_tok(char *delimiter_str, t_blst **delimiter_node);
 
 // #Description
 // Update the token string to the heredoc string.
@@ -23,7 +23,6 @@ int	parse_heredoc(t_blst **tokens_lst)
 {
 	t_blst			*now_node;
 	t_token_data	*data;
-	char			*delim_str;
 	int				err;
 
 	now_node = *tokens_lst;
@@ -32,12 +31,7 @@ int	parse_heredoc(t_blst **tokens_lst)
 		data = now_node->u_data.token_data;
 		if (data->token_type == HEREDOC_FLAG)
 		{
-			delim_str = get_delimiter(
-					now_node->next->u_data.token_data->token_str);
-			if (delim_str == NULL)
-				return (ERR);
-			err = replace_delimiter_as_token(delim_str, &(now_node->next));
-			free(delim_str);
+			err = get_and_replace_delim(now_node);
 			if (err == ERR || err == ERR_SIGINT)
 				return (err);
 			now_node = now_node->next;
@@ -47,26 +41,46 @@ int	parse_heredoc(t_blst **tokens_lst)
 	return (OK);
 }
 
-static int	replace_delimiter_as_token(
-				char *delimiter_str, t_blst **delimiter_node)
+static int	get_and_replace_delim(t_blst *now_node)
+{
+	char	*delimiter_str;
+	int		err;
+
+	delimiter_str = get_delimiter(now_node);
+	if (delimiter_str == NULL)
+		return (ERR);
+	if (now_node->next->u_data.token_data->token_type == SPACE_FLAG)
+		err = replace_delim_as_tok(delimiter_str, &(now_node->next->next));
+	else
+		err = replace_delim_as_tok(delimiter_str, &(now_node->next));
+	free(delimiter_str);
+	return (err);
+}
+
+static int	replace_delim_as_tok(char *delimiter_str,
+		t_blst **delimiter_node)
 {
 	t_token_data	*delimiter_data;
 	int				err;
 
-	if (delimiter_str == NULL
-		|| delimiter_node == NULL || *delimiter_node == NULL)
+	if (delimiter_str == NULL || delimiter_node == NULL
+		|| *delimiter_node == NULL)
 		return (ERR);
 	delimiter_data = (*delimiter_node)->u_data.token_data;
-	err = set_heredoc_string_to_node(
-			delimiter_str, delimiter_data);
+	err = set_heredoc_string_to_node(delimiter_str, delimiter_data);
 	return (err);
 }
 
-static char	*get_delimiter(char *delimiter_str)
+static char	*get_delimiter(t_blst *now_node)
 {
 	size_t	i;
+	char	*delimiter_str;
 	char	*ret;
 
+	if (now_node->next->u_data.token_data->token_type == SPACE_FLAG)
+		delimiter_str = now_node->next->next->u_data.token_data->token_str;
+	else
+		delimiter_str = now_node->next->u_data.token_data->token_str;
 	i = 0;
 	while (delimiter_str[i] != '\0' && delimiter_str[i] != '\n')
 		i++;
@@ -74,30 +88,4 @@ static char	*get_delimiter(char *delimiter_str)
 	if (ret == NULL)
 		return (NULL);
 	return (ret);
-}
-
-void	update_token_str_data(
-				t_token_data *target_data, char *new_token_str)
-{
-	int		type;	
-
-	type = is_flag(new_token_str, target_data->token_type);
-	free(target_data->token_str);
-	target_data->token_str = new_token_str;
-	target_data->token_type = type;
-}
-
-//data->token_typeとheredoc_strから、"$VAL"か'VAL'か"VAL"かを判断して、FLAGを割り当てる
-// Need fix
-int	is_flag(char *heredoc_str, int type) // Check later
-{
-	if (type == SINGLE_QUOTE_FLAG)
-		return (SINGLE_QUOTE_FLAG);
-	else
-	{
-		if (is_val(heredoc_str))
-			return (DOUBLE_QUOTE_VAL_FLAG);
-		else
-			return (DOUBLE_QUOTE_FLAG);
-	}
 }

--- a/src/tokens/heredoc_util.c
+++ b/src/tokens/heredoc_util.c
@@ -55,6 +55,8 @@ static char	*read_heredoc_lines(char *delimiter)
 	while (1)
 	{
 		line = readline("> ");
+		if (line == NULL && g_signal == 0)
+			ft_putstr_fd("\n", 2);
 		if (line == NULL || g_signal != 0)
 			break ;
 		if (ft_strcmp(line, delimiter) == 0)
@@ -83,4 +85,30 @@ static char	*append_newline(char *all_line, char *line)
 	if (ret_with_nl == NULL)
 		return (NULL);
 	return (ret_with_nl);
+}
+
+void	update_token_str_data(
+				t_token_data *target_data, char *new_token_str)
+{
+	int		type;	
+
+	type = is_flag(new_token_str, target_data->token_type);
+	free(target_data->token_str);
+	target_data->token_str = new_token_str;
+	target_data->token_type = type;
+}
+
+//data->token_typeとheredoc_strから、"$VAL"か'VAL'か"VAL"かを判断して、FLAGを割り当てる
+// Need fix
+int	is_flag(char *heredoc_str, int type) // Check later
+{
+	if (type == SINGLE_QUOTE_FLAG)
+		return (SINGLE_QUOTE_FLAG);
+	else
+	{
+		if (is_val(heredoc_str))
+			return (DOUBLE_QUOTE_VAL_FLAG);
+		else
+			return (DOUBLE_QUOTE_FLAG);
+	}
 }


### PR DESCRIPTION
fix #147 

空白がトークンではなかったときのコードだったため、nextでデリミタの位置を指定していた。ifによってデリミタの正しい位置を指定できるようにした。