### PR TITLE
親ディレクトリを削除してcdしたときのエラーメッセージの修正

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -120,6 +120,7 @@ int		cd_argc_err(void);
 int		cd_home_not_set_err(void);
 int		cd_option_err(char *cmd);
 int		cd_move_err(char *path);
+int		cd_cwd_error(void);
 
 int		export_option_err(char flag_char);
 int		export_identifier_err(char *str);

--- a/src/builtin/builtin_cd.c
+++ b/src/builtin/builtin_cd.c
@@ -20,7 +20,6 @@ static int	normalize_path(
 static int	valid_option(
 				char **cmd, char **path, int *options, t_blst *envlst);
 static int	flag_parser(char *flag_str);
-static void	free_all_params(t_cd_path_routing *param);
 
 /**
  * @brief Executes the built-in command "cd".
@@ -38,6 +37,7 @@ int	builtin_cd(char **cmd, t_blst **envlst, int mode)
 	int					status;
 	char				*path;
 	int					options;
+	int					err;
 
 	if (mode == IS_CHILD_PROCESS)
 		return (OK);
@@ -46,12 +46,9 @@ int	builtin_cd(char **cmd, t_blst **envlst, int mode)
 		return (status);
 	if (normalize_path(path, *envlst, &routing) > 0)
 		return (ERR_ALLOCATE_MEMORY);
-	if (chdir(routing.dist) == -1)
-	{
-		cd_move_err(path);
-		free_all_params(&routing);
-		return (GENERAL_ERR);
-	}
+	err = cd_check_err(path, &routing);
+	if (err == ERR_ALLOCATE_MEMORY || err == GENERAL_ERR)
+		return (err);
 	status = update_pwd_and_oldpwd_env(routing.src, routing.dist, envlst);
 	free_all_params(&routing);
 	if (status != OK)
@@ -143,7 +140,7 @@ static int	flag_parser(char *flag_str)
 	return (flag);
 }
 
-static void	free_all_params(t_cd_path_routing *param)
+void	free_all_params(t_cd_path_routing *param)
 {
 	if (param->src != NULL)
 		free(param->src);

--- a/src/builtin/builtin_cd_utils.c
+++ b/src/builtin/builtin_cd_utils.c
@@ -15,6 +15,8 @@
 #include "env.h"
 #include "libft.h"
 
+static int	cwd_check(char *path, t_cd_path_routing *routing);
+
 char	*allocate_cwd_path(t_blst *envlst)
 {
 	t_blst	*target_node;
@@ -82,5 +84,51 @@ int	get_home_path(char **path, t_blst *envlst)
 		*path = target_node->u_data.env_data->val;
 	if (*path == NULL)
 		return (cd_home_not_set_err());
+	return (OK);
+}
+
+int	cd_check_err(char *path, t_cd_path_routing *routing)
+{
+	int	err;
+
+	if (chdir(routing->dist) == -1)
+	{
+		err = cwd_check(path, routing);
+		if (err == ERR_ALLOCATE_MEMORY)
+			return (ERR_ALLOCATE_MEMORY);
+		else if (err == OK)
+		{
+			cd_move_err(path);
+			free_all_params(routing);
+			return (GENERAL_ERR);
+		}
+	}
+	return (OK);
+}
+
+static int	cwd_check(char *path, t_cd_path_routing *routing)
+{
+	char	*cwd;
+	char	*tmp;
+
+	cwd = getcwd(NULL, 0);
+	if (cwd == NULL)
+	{
+		cd_cwd_error();
+		tmp = ft_strjoin(routing->src, "/");
+		if (tmp == NULL)
+			return (ERR_ALLOCATE_MEMORY);
+		free(routing->dist);
+		routing->dist = ft_strjoin(tmp, path);
+		if (routing->dist == NULL)
+		{
+			free(tmp);
+			return (ERR_ALLOCATE_MEMORY);
+		}
+		free(tmp);
+		free(cwd);
+		return (ERR);
+	}
+	free(cwd);
 	return (OK);
 }

--- a/src/builtin/builtin_int.h
+++ b/src/builtin/builtin_int.h
@@ -38,11 +38,13 @@ int		update_or_create_env(char *key, char *value, t_blst **envlst);
 
 // builtin_cd.c
 int		builtin_cd(char **cmd, t_blst **envlst, int mode);
+void	free_all_params(t_cd_path_routing *param);
 // builtin_cd_utils.c
 char	*allocate_cwd_path(t_blst *envlst);
 int		update_pwd_and_oldpwd_env(
 			char *old_pwd, char *new_pwd, t_blst **envlst);
 int		get_home_path(char **path, t_blst *envlst);
+int		cd_check_err(char *path, t_cd_path_routing *routing);
 // builtin_cd_path_utils.c
 char	*path_resolving(char *abspath);
 

--- a/src/common/bin_err_cd.c
+++ b/src/common/bin_err_cd.c
@@ -45,3 +45,13 @@ int	cd_move_err(char *path)
 	ft_putstr_fd(": No such file or directory\n", 2);
 	return (GENERAL_ERR);
 }
+
+int	cd_cwd_error(void)
+{
+	ft_putstr_fd("cd: ", 2);
+	ft_putstr_fd("error retrieving current directory: ", 2);
+	ft_putstr_fd("getcwd: ", 2);
+	ft_putstr_fd("cannot access parent directories: ", 2);
+	ft_putstr_fd("No such file or directory\n", 2);
+	return (GENERAL_ERR);
+}


### PR DESCRIPTION
fix #157 

**実行比較**
- minishell
```
minishell$ mkdir e
minishell$ mkdir e/f
minishell$ cd e/f/
minishell$ pwd
/home/syamasaw/Desktop/test/e/f
minishell$ rm -r ../../e
minishell$ cd ..
cd: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
minishell$ echo $?
0
minishell$ echo $PWD
/home/syamasaw/Desktop/test/e/f/..
minishell$
```
- bash
```
$ mkdir e
$ mkdir e/f
$ cd e/f
$ rm -r ../../e
$ cd ..
cd: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
$ echo $?
0
$ echo $PWD
/home/syamasaw/Desktop/test/e/f/..
$
```