### PR TITLE
update: exit status の取得が終了タイミングに依存しないように修正

### DIFF
--- a/src/exec/Makefile
+++ b/src/exec/Makefile
@@ -11,9 +11,8 @@ INT_HEADERS := exec_int.h
 SRCS :=
 
 SRCS += exec.c
-# SRCS += find_cmd.c
 SRCS += process.c
-SRCS += process_utils.c
+SRCS += process_wait.c
 SRCS += process_callback.c
 SRCS += parse_cmd.c
 SRCS += parse_redirects.c

--- a/src/exec/exec_int.h
+++ b/src/exec/exec_int.h
@@ -6,7 +6,7 @@
 /*   By: saraki <saraki@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/03 17:23:14 by saraki            #+#    #+#             */
-/*   Updated: 2024/09/13 07:22:00 by saraki           ###   ########.fr       */
+/*   Updated: 2024/09/13 09:05:53 by saraki           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,10 +56,15 @@ int				exec(
 // process.c
 int				make_each_process(
 					t_exec_parametors *param, t_callback callback);
-
-// process_utils.c
 int				init_pipeline(t_blst *pipe_node);
+
+// process_wait.c
 int				wait_processes(t_pipelst *pipe_node);
+
+// process_callback.c
+void			do_first_process(t_callback_parametors *params);
+void			do_middle_process(t_callback_parametors *params);
+void			do_last_process(t_callback_parametors *params);
 
 // parse_cmd.c
 char			**parse_cmd(t_tokenlst *token_list, t_pipex *pipe,
@@ -73,10 +78,5 @@ int				parse_redirects(t_tokenlst *now_node, t_pipex *pipe);
 // parse_redirects_util.c
 int				open_existing_file_for_write(char *dist, int appendflag);
 int				open_file_for_read(char *dist);
-
-// process_callback.c
-void			do_first_process(t_callback_parametors *params);
-void			do_middle_process(t_callback_parametors *params);
-void			do_last_process(t_callback_parametors *params);
 
 #endif

--- a/src/exec/process.c
+++ b/src/exec/process.c
@@ -6,7 +6,7 @@
 /*   By: saraki <saraki@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/04 15:25:30 by saraki            #+#    #+#             */
-/*   Updated: 2024/09/13 08:16:57 by saraki           ###   ########.fr       */
+/*   Updated: 2024/09/13 09:04:20 by saraki           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,7 @@
 
 static int	run_command(t_callback_parametors *callback_args,
 				t_exec_parametors *param, t_callback callback);
+static int	pipe_fds(int *out_fd, int *in_fd);
 static void	init_signal_by_pid(pid_t pid);
 
 /**
@@ -97,4 +98,36 @@ static void	init_signal_by_pid(pid_t pid)
 		init_signal(SIG_DFL, SIG_DFL);
 	else
 		init_signal(SIG_IGN, SIG_IGN);
+}
+
+int	init_pipeline(t_pipelst *pipe_node)
+{
+	t_pipex	*pipe;
+	t_pipex	*next_pipe;
+
+	while (pipe_node->u_data.pipe_data != NULL)
+	{
+		pipe = (t_pipex *) pipe_node->u_data.pipe_data;
+		if (pipe_node->next->u_data.pipe_data != NULL)
+		{
+			next_pipe = pipe_node->next->u_data.pipe_data;
+			if (pipe_fds(&next_pipe->pipe_out_fd, &pipe->pipe_in_fd))
+				return (ERR);
+		}
+		pipe_node = pipe_node->next;
+	}
+	return (OK);
+}
+
+static int	pipe_fds(int *out_fd, int *in_fd)
+{
+	int	pipe_fd[2];
+
+	pipe_fd[0] = *out_fd;
+	pipe_fd[1] = *in_fd;
+	if (pipe(pipe_fd) < 0)
+		return (ERR);
+	*out_fd = pipe_fd[0];
+	*in_fd = pipe_fd[1];
+	return (OK);
 }

--- a/src/exec/process_wait.c
+++ b/src/exec/process_wait.c
@@ -1,75 +1,59 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   process_utils.c                                    :+:      :+:    :+:   */
+/*   process_wait.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: saraki <saraki@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2024/04/03 18:47:48 by saraki            #+#    #+#             */
-/*   Updated: 2024/08/29 21:13:22 by saraki           ###   ########.fr       */
+/*   Created: 2024/09/13 08:56:58 by saraki            #+#    #+#             */
+/*   Updated: 2024/09/14 11:04:45 by saraki           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "exec_int.h"
-#include "libft.h"
-#include "minishell.h"
 
+static int	cmp_pid(void *data, void *query_pt);
 static void	close_pipe_fds(t_pipelst *pipe_node);
-static int	pipe_fds(int *out_fd, int *in_fd);
 static int	check_status(int status);
-
-int	init_pipeline(t_pipelst *pipe_node)
-{
-	t_pipex	*pipe;
-	t_pipex	*next_pipe;
-
-	while (pipe_node->u_data.pipe_data != NULL)
-	{
-		pipe = (t_pipex *) pipe_node->u_data.pipe_data;
-		if (pipe_node->next->u_data.pipe_data != NULL)
-		{
-			next_pipe = pipe_node->next->u_data.pipe_data;
-			if (pipe_fds(&next_pipe->pipe_out_fd, &pipe->pipe_in_fd))
-				return (ERR);
-		}
-		pipe_node = pipe_node->next;
-	}
-	return (OK);
-}
-
-static int	pipe_fds(int *out_fd, int *in_fd)
-{
-	int	pipe_fd[2];
-
-	pipe_fd[0] = *out_fd;
-	pipe_fd[1] = *in_fd;
-	if (pipe(pipe_fd) < 0)
-		return (ERR);
-	*out_fd = pipe_fd[0];
-	*in_fd = pipe_fd[1];
-	return (OK);
-}
 
 int	wait_processes(t_pipelst *pipe_node)
 {
 	int			status;
+	pid_t		exited_pid;
+	t_pipelst	*exited_node;
 	int			err;
-	t_pipex		*data;
 
 	status = OK;
 	err = 0;
 	close_pipe_fds(pipe_node);
 	while (pipe_node->u_data.pipe_data != NULL)
 	{
-		data = pipe_node->u_data.pipe_data;
-		if (data->pids != 0 && waitpid(-1, &(data->exit_status), 0) == -1)
+		exited_pid = waitpid(-1, &status, 0);
+		if (exited_pid == -1)
+			err = GENERAL_ERR;
+		exited_node = (t_pipelst *)doub_lstsearch(
+				pipe_node->u_data.pipe_data->head_node, &exited_pid, cmp_pid);
+		if (exited_node->u_data.pipe_data != NULL)
+			exited_node->u_data.pipe_data->exit_status = status;
+		else
 			err = GENERAL_ERR;
 		pipe_node = pipe_node->next;
 	}
 	if (err != 0)
 		return (err);
-	status = pipe_node->next->u_data.pipe_data->exit_status;
-	return (check_status(status));
+	return (check_status(pipe_node->next->u_data.pipe_data->exit_status));
+}
+
+static int	cmp_pid(void *data, void *query_pt)
+{
+	pid_t		*pid;
+	t_pipex		*pipe_data;
+
+	pid = (pid_t *)query_pt;
+	pipe_data = (t_pipex *)data;
+	if (pipe_data->pids == *pid)
+		return (1);
+	return (0);
 }
 
 static void	close_pipe_fds(t_pipelst *pipe_node)


### PR DESCRIPTION
waitpidにpidの指定を行っていないため、任意の子プロセスの終了を待つ。それ故、パイプ最後のプロセスの終了ステータスを確定で取得できるように、pidとexit statusの対応を取るように修正した。

Squashed commit of the following:

commit e06f46ee4fef6dd428f69f18b9e8601f47274da8
Author: GawinGowin <saraki@student.42tokyo.jp>
Date:   Sat Sep 14 11:08:13 2024 +0900

    fix

commit ee7195c9225a85db2f7b5b480a116582a42b1376
Author: GawinGowin <101625248+GawinGowin@users.noreply.github.com>
Date:   Sat Sep 14 01:57:04 2024 +0000

    tmp