### PR TITLE
echo ls | ./minishellでminishellが終了しない問題の修正

### DIFF
--- a/cmd/minishell/minishell.c
+++ b/cmd/minishell/minishell.c
@@ -34,9 +34,11 @@ int	main(int argc, char **argv, char **envp)
 {
 	void	*env_lst;
 	int		status;
+	int		flag;
 
 	(void)argc;
 	(void)argv;
+	flag = isatty(STDIN_FILENO);
 	env_lst = init_envlst(envp);
 	if (env_lst == NULL)
 		return (1);
@@ -45,9 +47,7 @@ int	main(int argc, char **argv, char **envp)
 		init_signal(handler_for_outer_readline, SIG_IGN);
 		init_rl_for_prompt();
 		status = main_loop(env_lst);
-		if (status == ERR)
-			break ;
-		else if (status == EXIT_CALLED)
+		if (status == ERR || status == EXIT_CALLED || flag == 0)
 			break ;
 		else if (status == CONTINUE)
 			continue ;


### PR DESCRIPTION
isatty(stdin)=0(標準入力がパイプ)のとき、mainループ1回目終了時に2回目に入らずbreakするように変更

minishellの場合、minishell$ lsがコマンド結果の前に表示される問題があるため、課題提出にこれを含めるならisattyが0のときにこれらを消す必要がある。
```
// minishell
(SHLVL=1)$ echo ls | ./minishell_debug 
minishell$ ls
Makefile  Minishell.pdf  README.md  build  cmd  firebase.json  include  inf_loop.out  lib  minishell_debug  src  test  tmp
(SHLVL=1)$

// bash
(SHLVL=1)$ echo ls | bash
Makefile  Minishell.pdf  README.md  a.out  build  cmd  firebase.json  include  inf_loop.out  lib  minishell_debug  src  test  tmp
(SHLVL=1)$ 
```